### PR TITLE
Reject same-team matchup requests

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -60,6 +60,7 @@
   - `shared.team1_spread`
 - Any subset of fields is still accepted.
 - Duplicate `id` values in the same request are rejected with `400`.
+- Same-team matchups are rejected with `400` after trimming whitespace and comparing team names case-insensitively.
 
 ### Spread convention
 
@@ -111,5 +112,6 @@
 
 - `200` success
 - `400` contract or business-rule error, such as duplicate ids
+- `400` same-team matchup, such as `team1` and `team2` both naming the same team
 - `422` malformed request payload
 - `500` internal server error

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Spread convention used:
 
 - Invalid JSON, invalid shape, or empty fields -> `422`
 - Duplicate `id` values in one request -> `400`
+- Same-team matchup where `team1` and `team2` name the same team -> `400`
 - Unexpected server error -> `500`
 
 ## Tests

--- a/app/main.py
+++ b/app/main.py
@@ -100,6 +100,10 @@ def _format_context_lines(matchup: Matchup) -> str:
     )
 
 
+def _normalize_team_name(team_name: str) -> str:
+    return " ".join(team_name.casefold().split())
+
+
 def _extract_team1_spread(matchup: Matchup) -> float | None:
     if not matchup.context or not matchup.context.shared:
         return None
@@ -645,6 +649,11 @@ def analyze_matchup(payload: AnalyzeMatchupRequest) -> AnalyzeMatchupResponse:
             raise HTTPException(
                 status_code=400,
                 detail=f"Duplicate matchup id '{matchup.id}' in request.",
+            )
+        if _normalize_team_name(matchup.team1) == _normalize_team_name(matchup.team2):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Matchup '{matchup.id}' must include two different teams.",
             )
 
         seen_ids.add(matchup.id)

--- a/backlog/issues.yml
+++ b/backlog/issues.yml
@@ -12,48 +12,38 @@ milestones:
     state: open
 
 issues:
-  - id: final-sprint-feature-structured-spread-response
-    title: "Feature: return structured spread analysis fields"
-    labels:
-      - enhancement
-    milestone: Sprint 4
-    body: |
-      ## Feature
-      Expand the matchup analysis response from a single opinion string into a structured spread analysis result.
-
-      ## Motivation
-      The backend needs stable fields it can consume directly instead of parsing freeform text. The service should return the spread verdict, projected margin, cover edge, projected score, and explanation while keeping the endpoint stable.
-
-      ## Acceptance criteria
-      - Response includes a `verdict` field for each matchup.
-      - Response includes `projected_margin`, `cover_edge`, and `projected_score`.
-      - Opinion text uses actual team names and summarizes the deterministic spread result.
-      - Missing spread or incomplete metric inputs return a conservative `too_close_to_call` result.
-      - API contract and tests are updated for the new response shape.
-
-      ## Resolution
-      Completed in commit https://github.com/ivan-liuliaev/ai-service/commit/b8612a2eae4b757cd68f0aa87c0887da6231a518: Refine spread engine and output contract.
-
-  - id: final-sprint-bug-projected-margin-display
-    title: "Bug: displayed margin did not match projected score"
+  - id: sprint-4-bug-same-team-matchup-validation
+    title: "Bug: service allows team1 and team2 to be the same team"
     labels:
       - bug
     milestone: Sprint 4
     body: |
       ## Problem
-      The service could display a projected margin and cover edge that did not match the rounded projected score shown to the user.
-
-      ## Example
-      A response could show a projected score of `117-106`, which implies an 11 point margin, while also displaying a projected margin such as `+10.3`.
+      The API accepts a matchup where `team1` and `team2` refer to the same team.
 
       ## Expected behavior
-      The displayed projected margin and cover edge should be consistent with the displayed projected score.
+      A matchup should require two different teams. Same-team matchups should be rejected before analysis.
 
       ## Acceptance criteria
-      - Opening opinion sentence uses a displayed margin derived from the displayed projected score when projected scores are available.
-      - Displayed cover edge is calculated from that same displayed margin.
-      - API contract and README examples show consistent score, margin, and cover edge values.
-      - Tests cover the displayed score/margin consistency case.
+      - `POST /analyze-matchup` returns `400` when `team1` and `team2` are the same after trimming whitespace and comparing case-insensitively.
+      - Valid matchups with different teams still return `200`.
+      - API tests cover same-team validation.
 
-      ## Resolution
-      Completed in commit https://github.com/ivan-liuliaev/ai-service/commit/877afd7dd219e4b6eb1ace06471455f0b17d257b: Align displayed margin with projected score.
+  - id: sprint-4-feature-incomplete-context-warnings
+    title: "Feature: include warnings for incomplete matchup context"
+    labels:
+      - enhancement
+    milestone: Sprint 4
+    body: |
+      ## Feature
+      Add structured warnings to each matchup result when important context is missing.
+
+      ## Motivation
+      The service can return `too_close_to_call` when spread or metric context is incomplete, but clients should not need to parse the opinion text to understand why.
+
+      ## Acceptance criteria
+      - Each result includes a `warnings` array.
+      - Missing spread adds `missing_team1_spread`.
+      - Missing net rating inputs add `missing_net_rating`.
+      - Complete matchup context returns an empty warnings array.
+      - API contract and tests are updated.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -427,6 +427,23 @@ def test_analyze_matchup_duplicate_id_returns_400() -> None:
     assert "Duplicate matchup id" in response.json()["detail"]
 
 
+def test_analyze_matchup_same_team_returns_400() -> None:
+    response = client.post(
+        "/analyze-matchup",
+        json={
+            "matchups": [
+                {
+                    "id": "same",
+                    "team1": " Boston Celtics ",
+                    "team2": "boston celtics",
+                }
+            ]
+        },
+    )
+    assert response.status_code == 400
+    assert "two different teams" in response.json()["detail"]
+
+
 def test_analyze_matchup_invalid_payload_returns_422() -> None:
     response = client.post("/analyze-matchup", json={"matchups": []})
     assert response.status_code == 422


### PR DESCRIPTION
Adds validation so `POST /analyze-matchup` rejects matchups where `team1` and `team2` name the same team after whitespace normalization and case-insensitive comparison.

Also refreshes `backlog/issues.yml` so the Sprint 4 backlog reflects the two current work items.

Validation:
- `.venv/bin/pytest tests/test_api.py -q`

Closes #4