### PR TITLE
Add incomplete context warnings

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -81,6 +81,7 @@
         "team1": 117,
         "team2": 106
       },
+      "warnings": [],
       "opinion": "The Boston Celtics cover the -4.5 spread with a projected 117-106 score, a +11.0-point margin, and a +6.5-point edge. Boston Celtics' +8.4 net rating and 70% line hit rate put them well ahead of this number. A projected pace of 100.3 and a +4.2 rebounding differential reinforce their ability to stay ahead on the glass and the scoreboard."
     }
   ]
@@ -98,6 +99,9 @@
 - `projected_margin` is the deterministic Team1 margin projection and may be `null` if the net-rating baseline is unavailable.
 - `cover_edge` is `projected_margin + team1_spread` and may be `null` if the spread is missing or the margin cannot be computed.
 - `projected_score` is an object with integer `team1` and `team2` projections, or `null` if the margin cannot be computed.
+- `warnings` is a list of structured warning codes for incomplete context:
+  - `missing_team1_spread`
+  - `missing_net_rating`
 - `opinion` is freeform text, now expected to use actual team names and summarize the verdict, score or margin, edge, and the key metrics behind the call.
 
 ## Reliability behavior

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ curl -s -X POST http://localhost:8000/analyze-matchup \
         "team1": 117,
         "team2": 106
       },
+      "warnings": [],
       "opinion": "The Boston Celtics cover the -4.5 spread with a projected 117-106 score, a +11.0-point margin, and a +6.5-point edge. Boston Celtics' +8.4 net rating and 70% line hit rate put them well ahead of this number. A projected pace of 100.3 and a +4.2 rebounding differential reinforce their ability to stay ahead on the glass and the scoreboard."
     }
   ]
@@ -138,6 +139,7 @@ Sanity checks covered:
 
 - valid request without context
 - requested four-metric projection path
+- structured warnings for incomplete context
 - commutative spread math on team swap
 - duplicate id handling
 - invalid payload handling

--- a/app/main.py
+++ b/app/main.py
@@ -63,6 +63,7 @@ class MatchupResult(BaseModel):
     projected_margin: float | None
     cover_edge: float | None
     projected_score: ProjectedScore | None
+    warnings: list[str]
     opinion: str
 
 
@@ -140,6 +141,18 @@ def _metric(metrics: dict[str, float], key: str) -> float | None:
     if value is None:
         return None
     return float(value)
+
+
+def _build_warnings(matchup: Matchup) -> list[str]:
+    warnings: list[str] = []
+    team1, team2 = _team_metrics(matchup)
+
+    if _extract_team1_spread(matchup) is None:
+        warnings.append("missing_team1_spread")
+    if _metric(team1, "net_rating") is None or _metric(team2, "net_rating") is None:
+        warnings.append("missing_net_rating")
+
+    return warnings
 
 
 def _normalize_hit_rate(value: float | None) -> float | None:
@@ -625,6 +638,7 @@ def _build_result(matchup: Matchup) -> MatchupResult:
         projected_margin=_display_projected_margin(decision),
         cover_edge=_display_cover_edge(decision),
         projected_score=projected_score,
+        warnings=_build_warnings(matchup),
         opinion=generate_opinion(matchup, decision),
     )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,6 +34,7 @@ def test_analyze_matchup_success_without_context() -> None:
     assert body["results"][0]["projected_margin"] is None
     assert body["results"][0]["cover_edge"] is None
     assert body["results"][0]["projected_score"] is None
+    assert body["results"][0]["warnings"] == ["missing_team1_spread", "missing_net_rating"]
     assert "Boston Celtics" in body["results"][0]["opinion"]
     assert "Team1" not in body["results"][0]["opinion"]
 
@@ -73,6 +74,7 @@ def test_analyze_matchup_uses_requested_metric_set() -> None:
     assert result["projected_margin"] == 11.0
     assert result["cover_edge"] == 6.5
     assert result["projected_score"] == {"team1": 117, "team2": 106}
+    assert result["warnings"] == []
     assert result["opinion"].startswith("The Boston Celtics cover the -4.5 spread")
     assert "Team1" not in result["opinion"]
 
@@ -384,6 +386,7 @@ def test_missing_spread_returns_projection_but_not_cover_edge() -> None:
     assert result["projected_margin"] is not None
     assert result["cover_edge"] is None
     assert result["projected_score"] is not None
+    assert result["warnings"] == ["missing_team1_spread"]
 
 
 def test_missing_net_rating_forces_too_close() -> None:
@@ -411,6 +414,30 @@ def test_missing_net_rating_forces_too_close() -> None:
     assert result["projected_margin"] is None
     assert result["cover_edge"] is None
     assert result["projected_score"] is None
+    assert result["warnings"] == ["missing_net_rating"]
+
+
+def test_context_warnings_include_each_missing_input_once() -> None:
+    response = client.post(
+        "/analyze-matchup",
+        json={
+            "matchups": [
+                {
+                    "id": "warnings",
+                    "team1": "Miami Heat",
+                    "team2": "Atlanta Hawks",
+                    "context": {
+                        "team1": {"pace": 97.2},
+                        "team2": {"net_rating": 1.4, "pace": 99.8},
+                    },
+                }
+            ]
+        },
+    )
+    assert response.status_code == 200
+
+    result = response.json()["results"][0]
+    assert result["warnings"] == ["missing_team1_spread", "missing_net_rating"]
 
 
 def test_analyze_matchup_duplicate_id_returns_400() -> None:


### PR DESCRIPTION
Adds a structured `warnings` array to each matchup result so clients can identify incomplete input context without parsing opinion text.

Warning codes added:
- `missing_team1_spread`
- `missing_net_rating`

Validation:
- `.venv/bin/pytest tests/test_api.py -q`

Closes #5